### PR TITLE
Suggested git protocol: append jira story to branch name

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -26,6 +26,10 @@ Create a local feature branch based off master.
 
 Prefix the branch name with your initials.
 
+Append the Jira(or other tracking system) story id to your branch name. Example:
+
+    sd-add_profile_pic_to_header-FST21
+
 Rebase frequently to incorporate upstream changes.
 
     git fetch origin


### PR DESCRIPTION
As a best practice, I suggest we append a story id to our branch names. That way someone can easily map a branch to the Jira story for context.
